### PR TITLE
Update manifest.json

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
-  "domain": "https://github.com/Legomaniac",
-  "name": "lacrosse_alerts_mobile",
+  "domain": "lacrosse_alerts_mobile",
+  "name": "Lacrosse Alerts Mobile",
   "documentation": "https://github.com/Legomaniac/hass_lacrosse_alerts_mobile/blob/master/README.md",
   "dependencies": [],
   "codeowners": ["Legomaniac"],


### PR DESCRIPTION
Custom integration failing to install on recent version of HA (2022.5.5), found the issue was with 'domain' key in the manifest.  Updated `domain` to follow the current HA manifest conventions. Aka, must match the directory name.

_Citation from https://developers.home-assistant.io/docs/creating_integration_manifest:_

> 'The domain is a short name consisting of characters and underscores. This domain has to be unique and cannot be changed. Example of the domain for the mobile app integration: mobile_app. The domain key has to match the directory this file is in.'